### PR TITLE
Fix binary FBX small arrays corruption

### DIFF
--- a/Fbx/FbxBinaryWriter.cs
+++ b/Fbx/FbxBinaryWriter.cs
@@ -112,7 +112,7 @@ namespace Fbx
 			DeflateWithChecksum codec = null;
 
 			var compressLengthPos = stream.BaseStream.Position;
-			stream.Write(0); // Placeholder compressed length
+			stream.Write(size); // Placeholder compressed length
 			var dataStart = stream.BaseStream.Position;
 			if (compress)
 			{


### PR DESCRIPTION
When arrays are small they are not compressed.  This change fixes the "compressed length" field being left zero in this case, instead of writing the uncompressed length again.  While Autodesk FBX Review can read files before this change without any issues, Unity 2019.1 does not, resulting in missing materials.